### PR TITLE
Add substitute member count to Committee model and update council detail template

### DIFF
--- a/app/local/models.py
+++ b/app/local/models.py
@@ -119,7 +119,12 @@ class Committee(models.Model):
     def member_count(self):
         """Number of active members in the committee (excluding substitute members)"""
         return self.members.filter(is_active=True).exclude(role='substitute_member').count()
-    
+
+    @property
+    def substitute_member_count(self):
+        """Number of active substitute members in the committee"""
+        return self.members.filter(is_active=True, role='substitute_member').count()
+
     @property
     def chairperson_member(self):
         """Get the chairperson from committee members"""

--- a/app/templates/local/council_detail.html
+++ b/app/templates/local/council_detail.html
@@ -246,7 +246,7 @@
                                                 {% endif %}
                                             </td>
                                             <td>
-                                                <span class="text-muted">{{ committee.member_count }}</span>
+                                                <span class="text-muted">{{ committee.member_count }}{% if committee.substitute_member_count %} ({{ committee.substitute_member_count }}){% endif %}</span>
                                             </td>
                                         </tr>
                                     {% endfor %}


### PR DESCRIPTION
- Introduced a new property `substitute_member_count` in the Committee model to count active substitute members.
- Updated the council detail template to display the count of substitute members alongside the total active members.