### PR TITLE
Enhance CommitteeMeetingForm title formatting and update badge label in calendar events

### DIFF
--- a/app/local/forms.py
+++ b/app/local/forms.py
@@ -480,7 +480,7 @@ class CommitteeMeetingForm(forms.ModelForm):
             committee = self.cleaned_data.get('committee')
             scheduled_date = self.cleaned_data.get('scheduled_date')
             if committee and scheduled_date:
-                self.instance.title = f"{committee.name} {scheduled_date.strftime('%d.%m.%Y %H:%M')}"
+                self.instance.title = f"{committee.name} {scheduled_date.strftime('%d.%m.%Y')}"
             self.instance.is_active = True
         return super().save(commit=commit)
 

--- a/app/pages/views.py
+++ b/app/pages/views.py
@@ -284,7 +284,7 @@ def _get_personal_calendar_events(user, group_memberships, councils_from_members
                 'url': m.get_absolute_url(),
                 'ics_export_url': reverse('local:committee-meeting-export-ics', args=[m.pk]),
                 'type': 'committee_meeting',
-                'badge_label': _('Committee'),
+                'badge_label': m.committee.get_committee_type_display(),
                 'subtitle': m.committee.name,
                 'location': getattr(m, 'location', '') or '',
                 'pk': m.pk,


### PR DESCRIPTION
- Modified the CommitteeMeetingForm to format the title based on the committee type, displaying the scheduled date differently for 'Kommission' types.
- Updated the badge label in the personal calendar events to reflect the committee type dynamically instead of a static label.