### PR TITLE
Fix language selection being overridden by browser locale

### DIFF
--- a/app/main/settings.py
+++ b/app/main/settings.py
@@ -69,8 +69,8 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'user.middleware.UserLanguageMiddleware',  # Custom language middleware - must be after auth
-    'django.middleware.locale.LocaleMiddleware',  # After our custom middleware
+    'django.middleware.locale.LocaleMiddleware',
+    'user.middleware.UserLanguageMiddleware',  # Custom language middleware - must be after auth and locale
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'allauth.account.middleware.AccountMiddleware',
@@ -87,6 +87,7 @@ TEMPLATES = [
             'context_processors': [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.i18n',
                 'django.contrib.messages.context_processors.messages',
                 'pages.context_processors.group_memberships',
             ],

--- a/app/user/middleware.py
+++ b/app/user/middleware.py
@@ -17,5 +17,7 @@ class UserLanguageMiddleware(MiddlewareMixin):
                 request.session['django_language'] = user_language
                 # Activate the language for this request
                 translation.activate(user_language)
+                # Set LANGUAGE_CODE on request for other middleware/templates
+                request.LANGUAGE_CODE = user_language
         
         return None


### PR DESCRIPTION
# Fix language selection being overridden by browser locale

## Description
This PR addresses the issue where a user's chosen interface language (English/German) was only applied to the settings page and reverted to the browser's default locale on all other views.

## Root Cause
The bug was caused by three main factors:
1. **Middleware Ordering**: `LocaleMiddleware` was running after our custom language middleware, effectively overwriting our user preference with the browser's `Accept-Language` header.
2. **Missing Context**: The `i18n` context processor was not enabled, making the `LANGUAGE_CODE` variable unavailable or inconsistent in templates.
3. **Incomplete Request State**: The middleware activated the translator but did not update the `request.LANGUAGE_CODE` attribute, leading to desynchronization in some components.

## Changes
- **Middleware Reordering**: Moved `UserLanguageMiddleware` after `LocaleMiddleware` in `app/main/settings.py` so the user's database preference has the "last word."
- **Context Processor**: Enabled `django.template.context_processors.i18n` in `settings.py` to ensure consistent access to language variables in HTML templates.
- **Middleware Update**: Modified `app/user/middleware.py` to synchronize `request.LANGUAGE_CODE` with the activated translation.

## Related Issues
Fixes #85

## Testing performed
- **Manual**: Verified that switching from **German** (user setting) while the browser is set to **English** (browser default) persists correctly when navigating to the Home page, Motions, and Questions.
- **Automated**: Ran the following test suites in the Docker environment:
  - `user.tests.UserLanguageMiddlewareTests`
  - `user.tests.LanguageChangeFunctionalityTests`
  - **Result**: All 10 tests passed successfully.