### PR TITLE
Enhance committee meeting permissions

### DIFF
--- a/app/templates/local/committee_meeting_detail.html
+++ b/app/templates/local/committee_meeting_detail.html
@@ -81,7 +81,7 @@
                     <h5 class="mb-0">
                         <i class="bi bi-paperclip"></i> {% trans "Meeting Attachments" %}
                     </h5>
-                    {% if user.is_superuser %}
+                    {% if can_edit_committee_meeting %}
                     <a href="{% url 'local:committee-meeting-attach' meeting.pk %}" class="btn btn-sm btn-primary">
                         <i class="bi bi-upload"></i> {% trans "Upload File" %}
                     </a>


### PR DESCRIPTION
- Updated the logic for displaying the edit button to allow superusers and group leaders of relevant groups to edit committee meetings.
- Introduced a new helper function to check user permissions for editing committee meetings.
- Modified the test functions in the CommitteeMeetingUpdateView and CommitteeMeetingAttachmentView to utilize the new permission check.
- Updated the template to conditionally show the upload button based on the new permission logic.