### PR TITLE
Update file upload limits to 50MB across forms and templates

### DIFF
--- a/app/local/forms.py
+++ b/app/local/forms.py
@@ -527,9 +527,9 @@ class SessionAttachmentForm(forms.ModelForm):
     def clean_file(self):
         file = self.cleaned_data.get('file')
         if file:
-            # Check file size (max 10MB)
-            if file.size > 10 * 1024 * 1024:
-                raise forms.ValidationError("File size must be under 10MB.")
+            # Check file size (max 50MB)
+            if file.size > 50 * 1024 * 1024:
+                raise forms.ValidationError("File size must be under 50MB.")
             
             # Check file extension
             allowed_extensions = ['.pdf', '.doc', '.docx', '.txt', '.jpg', '.jpeg', '.png', '.gif', '.xls', '.xlsx', '.ppt', '.pptx']
@@ -572,8 +572,8 @@ class SessionInvitationForm(forms.Form):
         import os
         file = self.cleaned_data.get('file')
         if file:
-            if file.size > 10 * 1024 * 1024:
-                raise forms.ValidationError("File size must be under 10MB.")
+            if file.size > 50 * 1024 * 1024:
+                raise forms.ValidationError("File size must be under 50MB.")
             ext = os.path.splitext(file.name)[1].lower()
             if ext != '.pdf':
                 raise forms.ValidationError("Only PDF files are allowed for the invitation.")
@@ -608,8 +608,8 @@ class CommitteeMeetingAttachmentForm(forms.ModelForm):
     def clean_file(self):
         file = self.cleaned_data.get('file')
         if file:
-            if file.size > 10 * 1024 * 1024:
-                raise forms.ValidationError("File size must be under 10MB.")
+            if file.size > 50 * 1024 * 1024:
+                raise forms.ValidationError("File size must be under 50MB.")
             import os
             allowed_extensions = ['.pdf', '.doc', '.docx', '.txt', '.jpg', '.jpeg', '.png', '.gif', '.xls', '.xlsx', '.ppt', '.pptx']
             ext = os.path.splitext(file.name)[1].lower()

--- a/app/main/settings.py
+++ b/app/main/settings.py
@@ -163,6 +163,10 @@ STATICFILES_DIRS = [
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
+# File upload limits (50MB for committee meeting attachments and other uploads)
+DATA_UPLOAD_MAX_MEMORY_SIZE = 52 * 1024 * 1024  # 52MB (allows 50MB file + form overhead)
+FILE_UPLOAD_MAX_MEMORY_SIZE = 52 * 1024 * 1024  # 52MB
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/6.0/ref/settings/#default-auto-field
 

--- a/app/templates/local/committee_meeting_attachment_form.html
+++ b/app/templates/local/committee_meeting_attachment_form.html
@@ -46,7 +46,7 @@
                                         </div>
                                     {% endif %}
                                     <div class="form-text">
-                                        {% trans "Maximum file size: 10MB. Allowed types: PDF, DOC, DOCX, TXT, JPG, PNG, GIF, XLS, XLSX, PPT, PPTX" %}
+                                        {% trans "Maximum file size: 50MB. Allowed types: PDF, DOC, DOCX, TXT, JPG, PNG, GIF, XLS, XLSX, PPT, PPTX" %}
                                     </div>
                                 </div>
                             </div>

--- a/app/templates/local/session_attachment_form.html
+++ b/app/templates/local/session_attachment_form.html
@@ -47,7 +47,7 @@
                                         </div>
                                     {% endif %}
                                     <div class="form-text">
-                                        {% trans "Maximum file size: 10MB. Allowed types: PDF, DOC, DOCX, TXT, JPG, PNG, GIF, XLS, XLSX, PPT, PPTX" %}
+                                        {% trans "Maximum file size: 50MB. Allowed types: PDF, DOC, DOCX, TXT, JPG, PNG, GIF, XLS, XLSX, PPT, PPTX" %}
                                     </div>
                                 </div>
                             </div>

--- a/app/templates/local/session_invitation_form.html
+++ b/app/templates/local/session_invitation_form.html
@@ -46,7 +46,7 @@
                                     {% endfor %}
                                 </div>
                             {% endif %}
-                            <div class="form-text">{% trans "PDF only. Maximum file size: 10MB." %}</div>
+                            <div class="form-text">{% trans "PDF only. Maximum file size: 50MB." %}</div>
                         </div>
                         <div class="mb-3">
                             <label for="{{ form.description.id_for_label }}" class="form-label">


### PR DESCRIPTION
- Increased maximum file size limit from 10MB to 50MB for session attachments, session invitations, and committee meeting attachments in the forms.
- Updated corresponding templates to reflect the new file size limit.
- Adjusted settings to accommodate the new upload size limits for file uploads.