### PR TITLE
Refactor committee status management

### DIFF
--- a/app/local/forms.py
+++ b/app/local/forms.py
@@ -306,19 +306,17 @@ class CommitteeForm(forms.ModelForm):
     
     class Meta:
         model = Committee
-        fields = ['name', 'abbreviation', 'council', 'term', 'committee_type', 'status', 'description']
+        fields = ['name', 'abbreviation', 'council', 'term', 'committee_type', 'description']
         widgets = {
             'name': forms.TextInput(attrs={'class': 'form-control'}),
             'abbreviation': forms.TextInput(attrs={'class': 'form-control', 'maxlength': '20'}),
             'council': forms.Select(attrs={'class': 'form-select'}),
             'term': forms.Select(attrs={'class': 'form-select'}),
             'committee_type': forms.Select(attrs={'class': 'form-select'}),
-            'status': forms.Select(attrs={'class': 'form-select'}),
             'description': forms.Textarea(attrs={'class': 'form-control', 'rows': 3}),
         }
     
     def __init__(self, *args, **kwargs):
-        self.can_edit_status_only = kwargs.pop('can_edit_status_only', False)
         # On create: auto-select the last (most recent) term before super() so initial is used
         instance = kwargs.get('instance')
         if instance is None or getattr(instance, 'pk', None) is None:
@@ -347,12 +345,6 @@ class CommitteeForm(forms.ModelForm):
             except Council.DoesNotExist:
                 pass
 
-        # When group leaders edit: only allow changing status
-        if self.can_edit_status_only:
-            for field_name in list(self.fields.keys()):
-                if field_name != 'status':
-                    del self.fields[field_name]
-
 
 class CommitteeFilterForm(forms.Form):
     """Form for filtering committees in the committee list view"""
@@ -365,11 +357,6 @@ class CommitteeFilterForm(forms.Form):
     )
     committee_type = forms.ChoiceField(
         choices=[('', 'All Types')] + Committee.COMMITTEE_TYPE_CHOICES,
-        required=False,
-        widget=forms.Select(attrs={'class': 'form-select'})
-    )
-    status = forms.ChoiceField(
-        choices=[('', _('All Statuses'))] + list(Committee.STATUS_CHOICES),
         required=False,
         widget=forms.Select(attrs={'class': 'form-select'})
     )
@@ -453,13 +440,14 @@ class CommitteeMeetingForm(forms.ModelForm):
 
     class Meta:
         model = CommitteeMeeting
-        fields = ['committee', 'title', 'scheduled_date', 'location', 'description', 'is_active']
+        fields = ['committee', 'title', 'scheduled_date', 'location', 'description', 'status', 'is_active']
         widgets = {
             'committee': forms.Select(attrs={'class': 'form-select'}),
             'title': forms.TextInput(attrs={'class': 'form-control'}),
             'scheduled_date': forms.DateTimeInput(attrs={'type': 'datetime-local', 'class': 'form-control'}, format='%Y-%m-%dT%H:%M'),
             'location': forms.TextInput(attrs={'class': 'form-control'}),
             'description': forms.Textarea(attrs={'class': 'form-control', 'rows': 4}),
+            'status': forms.Select(attrs={'class': 'form-select'}),
             'is_active': forms.CheckboxInput(attrs={'class': 'form-check-input'}),
         }
 
@@ -472,9 +460,10 @@ class CommitteeMeetingForm(forms.ModelForm):
             self.fields['committee'].initial = committee
             if not self.instance.pk:
                 self.initial['committee'] = committee.pk
-        # On create: hide title and is_active; they are set in save()
+        # On create: hide title, status, and is_active; they are set in save()
         if not self.instance.pk:
             del self.fields['title']
+            del self.fields['status']
             del self.fields['is_active']
         else:
             # On edit: hide labels for title and is_active
@@ -494,6 +483,7 @@ class CommitteeMeetingForm(forms.ModelForm):
             scheduled_date = self.cleaned_data.get('scheduled_date')
             if committee and scheduled_date:
                 self.instance.title = f"{committee.name} {scheduled_date.strftime('%d.%m.%Y')}"
+            self.instance.status = 'scheduled'
             self.instance.is_active = True
         return super().save(commit=commit)
 

--- a/app/local/migrations/0037_committeemeeting_status_remove_committee_status.py
+++ b/app/local/migrations/0037_committeemeeting_status_remove_committee_status.py
@@ -1,0 +1,32 @@
+# Generated manually: add status to CommitteeMeeting, remove from Committee
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('local', '0036_committee_status'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='committee',
+            name='status',
+        ),
+        migrations.AddField(
+            model_name='committeemeeting',
+            name='status',
+            field=models.CharField(
+                choices=[
+                    ('scheduled', 'Scheduled'),
+                    ('completed', 'Completed'),
+                    ('cancelled', 'Cancelled'),
+                    ('invited', 'Invited'),
+                ],
+                default='scheduled',
+                help_text='Current status of the meeting',
+                max_length=20,
+            ),
+        ),
+    ]

--- a/app/local/models.py
+++ b/app/local/models.py
@@ -78,13 +78,6 @@ class Committee(models.Model):
         ('Kommission', 'Kommission'),
     ]
 
-    STATUS_CHOICES = [
-        ('scheduled', _('Scheduled')),
-        ('completed', _('Completed')),
-        ('cancelled', _('Cancelled')),
-        ('invited', _('Invited')),
-    ]
-
     name = models.CharField(max_length=200, help_text="Name of the committee")
     abbreviation = models.CharField(max_length=20, blank=True, help_text="Abbreviation for the committee (e.g., 'BA' for Budgetausschuss)")
     council = models.ForeignKey(Council, on_delete=models.CASCADE, related_name='committees', help_text="Council this committee belongs to")
@@ -97,12 +90,6 @@ class Committee(models.Model):
         help_text="Term this committee belongs to"
     )
     committee_type = models.CharField(max_length=20, choices=COMMITTEE_TYPE_CHOICES, default='standing', help_text="Type of committee")
-    status = models.CharField(
-        max_length=20,
-        choices=STATUS_CHOICES,
-        default='scheduled',
-        help_text=_("Current status of the committee"),
-    )
     description = models.TextField(blank=True, help_text="Description of the committee's purpose and responsibilities")
     chairperson = models.CharField(max_length=100, blank=True, help_text="Name of the committee chairperson")
     is_active = models.BooleanField(default=True, help_text="Whether the committee is currently active")
@@ -173,6 +160,13 @@ class Committee(models.Model):
 
 class CommitteeMeeting(models.Model):
     """Model representing a meeting of a committee (replaces committee sessions)."""
+    STATUS_CHOICES = [
+        ('scheduled', _('Scheduled')),
+        ('completed', _('Completed')),
+        ('cancelled', _('Cancelled')),
+        ('invited', _('Invited')),
+    ]
+
     committee = models.ForeignKey(
         Committee, on_delete=models.CASCADE, related_name='meetings',
         help_text="Committee holding the meeting"
@@ -186,6 +180,12 @@ class CommitteeMeeting(models.Model):
     scheduled_date = models.DateTimeField(help_text="Date and time when the meeting is scheduled")
     location = models.CharField(max_length=300, blank=True, help_text="Location where the meeting will be held")
     description = models.TextField(blank=True, help_text="Description or agenda of the meeting")
+    status = models.CharField(
+        max_length=20,
+        choices=STATUS_CHOICES,
+        default='scheduled',
+        help_text=_("Current status of the meeting"),
+    )
     is_active = models.BooleanField(default=True, help_text="Whether the meeting is currently active")
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/app/local/views.py
+++ b/app/local/views.py
@@ -1400,7 +1400,11 @@ def committee_meeting_export_ics(request, pk):
     meeting_url = request.build_absolute_uri(reverse('local:committee-meeting-detail', args=[meeting.pk]))
     lines.append(f"URL:{meeting_url}")
     lines.append(f"DTSTAMP:{timezone.now().astimezone(timezone.UTC).strftime('%Y%m%dT%H%M%SZ')}")
-    lines.extend(["STATUS:CONFIRMED", "END:VEVENT", "END:VCALENDAR"])
+    if getattr(meeting, 'status', None) == 'cancelled':
+        lines.append("STATUS:CANCELLED")
+    else:
+        lines.append("STATUS:CONFIRMED")
+    lines.extend(["END:VEVENT", "END:VCALENDAR"])
     ics_file = "\r\n".join(lines)
     response = HttpResponse(ics_file, content_type='text/calendar; charset=utf-8')
     filename = f"committee_meeting_{meeting.pk}_{meeting.title.replace(' ', '_')}.ics"
@@ -1831,11 +1835,6 @@ class CommitteeListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
         committee_type_filter = self.request.GET.get('committee_type', '')
         if committee_type_filter:
             queryset = queryset.filter(committee_type=committee_type_filter)
-
-        # Filter by status
-        status_filter = self.request.GET.get('status', '')
-        if status_filter:
-            queryset = queryset.filter(status=status_filter)
         
         # Filter by council
         council_filter = self.request.GET.get('council', '')
@@ -1849,14 +1848,12 @@ class CommitteeListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
         context = super().get_context_data(**kwargs)
         context['search_query'] = self.request.GET.get('search', '')
         context['committee_type_filter'] = self.request.GET.get('committee_type', '')
-        context['status_filter'] = self.request.GET.get('status', '')
         context['council_filter'] = self.request.GET.get('council', '')
         context['councils'] = Council.objects.filter(is_active=True)
         committees = context.get('committees') or context.get('object_list') or []
-        context['can_edit_committee_ids'] = {
-            c.pk for c in committees
-            if _can_user_edit_committee_status(self.request.user, c)
-        }
+        context['can_edit_committee_ids'] = (
+            {c.pk for c in committees} if self.request.user.is_superuser else set()
+        )
         return context
 
 
@@ -1890,9 +1887,7 @@ class CommitteeDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
         context = super().get_context_data(**kwargs)
         user = self.request.user
         # Permission flags: show edit/add buttons only to users who can access those views
-        context['can_edit_committee'] = (
-            user.is_superuser or _can_user_edit_committee_status(user, self.object)
-        )
+        context['can_edit_committee'] = user.is_superuser
         context['can_add_committee_member'] = (
             user.is_superuser
             or GroupMember.objects.filter(
@@ -1979,18 +1974,8 @@ class CommitteeUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     success_url = reverse_lazy('local:committee-list')
 
     def test_func(self):
-        """Check if user has permission to edit Committee. Superuser or group leader of a group connected to the council."""
-        committee = self.get_object()
-        return _can_user_edit_committee_status(self.request.user, committee)
-
-    def get_form_kwargs(self):
-        """Pass can_edit_status_only when user is group leader (not superuser) - they can only change status."""
-        kwargs = super().get_form_kwargs()
-        kwargs['can_edit_status_only'] = (
-            not self.request.user.is_superuser
-            and _can_user_edit_committee_status(self.request.user, self.get_object())
-        )
-        return kwargs
+        """Check if user has permission to edit Committee objects"""
+        return self.request.user.is_superuser
 
     def get_success_url(self):
         """Redirect to committee detail after edit"""
@@ -2162,22 +2147,6 @@ def _can_user_set_substitute_for_member(user, member, meeting=None):
     if meeting and _can_user_edit_committee_meeting(user, meeting):
         return True
     return False
-
-
-def _can_user_edit_committee_status(user, committee):
-    """Check if user can change committee status. Superuser or group leader of a group connected to the committee's council (same local)."""
-    if user.is_superuser:
-        return True
-    from group.models import GroupMember
-    council = committee.council
-    if not council or not council.local_id:
-        return False
-    return GroupMember.objects.filter(
-        user=user,
-        is_active=True,
-        roles__name__in=['Group Admin', 'Leader', 'Deputy Leader'],
-        group__party__local_id=council.local_id,
-    ).exists()
 
 
 def _can_user_edit_committee_meeting(user, meeting):

--- a/app/templates/local/committee_detail.html
+++ b/app/templates/local/committee_detail.html
@@ -44,10 +44,6 @@
                                 <dd class="col-sm-8">
                                     <span class="badge bg-secondary">{{ committee.get_committee_type_display }}</span>
                                 </dd>
-                                <dt class="col-sm-4">{% trans "Status" %}</dt>
-                                <dd class="col-sm-8">
-                                    <span class="badge bg-info">{{ committee.get_status_display }}</span>
-                                </dd>
                             </dl>
                         </div>
                         <div class="col-md-6">
@@ -206,11 +202,7 @@
                                                 {{ meeting.location|default:"-" }}
                                             </td>
                                             <td>
-                                                {% if meeting.is_past %}
-                                                    <span class="badge bg-secondary">{% trans "Past" %}</span>
-                                                {% else %}
-                                                    <span class="badge bg-success">{% trans "Upcoming" %}</span>
-                                                {% endif %}
+                                                <span class="badge {% if meeting.status == 'cancelled' %}bg-danger{% elif meeting.status == 'completed' %}bg-secondary{% elif meeting.status == 'invited' %}bg-info{% else %}bg-success{% endif %}">{{ meeting.get_status_display }}</span>
                                             </td>
                                             <td>
                                                 <div class="btn-group" role="group">

--- a/app/templates/local/committee_form.html
+++ b/app/templates/local/committee_form.html
@@ -183,26 +183,6 @@
                         </div>
                         {% endif %}
 
-                        {% if 'status' in form.fields %}
-                        <!-- Status -->
-                        <div class="mb-3">
-                            <label for="{{ form.status.id_for_label }}" class="form-label">
-                                {% trans "Status" %}
-                            </label>
-                            {{ form.status }}
-                            {% if form.status.errors %}
-                                <div class="invalid-feedback d-block">
-                                    {% for error in form.status.errors %}
-                                        {{ error }}
-                                    {% endfor %}
-                                </div>
-                            {% endif %}
-                            {% if form.status.help_text %}
-                                <div class="form-text">{{ form.status.help_text }}</div>
-                            {% endif %}
-                        </div>
-                        {% endif %}
-
                         {% if 'description' in form.fields %}
                         <!-- Description -->
                         <div class="mb-3">

--- a/app/templates/local/committee_list.html
+++ b/app/templates/local/committee_list.html
@@ -42,16 +42,6 @@
                             </select>
                         </div>
                         <div class="col-md-2">
-                            <label for="status" class="form-label">{% trans "Status" %}</label>
-                            <select class="form-select" id="status" name="status">
-                                <option value="">{% trans "All Statuses" %}</option>
-                                <option value="scheduled" {% if status_filter == 'scheduled' %}selected{% endif %}>{% trans "Scheduled" %}</option>
-                                <option value="completed" {% if status_filter == 'completed' %}selected{% endif %}>{% trans "Completed" %}</option>
-                                <option value="cancelled" {% if status_filter == 'cancelled' %}selected{% endif %}>{% trans "Cancelled" %}</option>
-                                <option value="invited" {% if status_filter == 'invited' %}selected{% endif %}>{% trans "Invited" %}</option>
-                            </select>
-                        </div>
-                        <div class="col-md-2">
                             <label for="council" class="form-label">{% trans "Council" %}</label>
                             <select class="form-select" id="council" name="council">
                                 <option value="">{% trans "All Councils" %}</option>
@@ -72,7 +62,7 @@
                         </div>
                     </form>
                     
-                    {% if search_query or committee_type_filter or status_filter or council_filter %}
+                    {% if search_query or committee_type_filter or council_filter %}
                         <div class="mt-3">
                             <a href="{% url 'local:committee-list' %}" class="btn btn-outline-secondary btn-sm">
                                 <i class="bi bi-x-circle"></i> {% trans "Clear Filters" %}
@@ -105,7 +95,6 @@
                                         <th>{% trans "Name" %}</th>
                                         <th>{% trans "Council" %}</th>
                                         <th>{% trans "Type" %}</th>
-                                        <th>{% trans "Status" %}</th>
                                         <th>{% trans "Chairperson" %}</th>
                                         <th>{% trans "Members" %}</th>
                                         <th>{% trans "Actions" %}</th>
@@ -132,9 +121,6 @@
                                             </td>
                                             <td>
                                                 <span class="badge bg-secondary">{{ committee.get_committee_type_display }}</span>
-                                            </td>
-                                            <td>
-                                                <span class="badge bg-info">{{ committee.get_status_display }}</span>
                                             </td>
                                             <td>
                                                 {% if committee.chairperson_name %}
@@ -175,12 +161,12 @@
                                 <ul class="pagination justify-content-center">
                                     {% if page_obj.has_previous %}
                                         <li class="page-item">
-                                            <a class="page-link" href="?page=1{% if search_query %}&search={{ search_query }}{% endif %}{% if committee_type_filter %}&committee_type={{ committee_type_filter }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if council_filter %}&council={{ council_filter }}{% endif %}">
+                                                <a class="page-link" href="?page=1{% if search_query %}&search={{ search_query }}{% endif %}{% if committee_type_filter %}&committee_type={{ committee_type_filter }}{% endif %}{% if council_filter %}&council={{ council_filter }}{% endif %}">
                                                 <i class="bi bi-chevron-double-left"></i>
                                             </a>
                                         </li>
                                         <li class="page-item">
-                                            <a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if committee_type_filter %}&committee_type={{ committee_type_filter }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if council_filter %}&council={{ council_filter }}{% endif %}">
+                                            <a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if committee_type_filter %}&committee_type={{ committee_type_filter }}{% endif %}{% if council_filter %}&council={{ council_filter }}{% endif %}">
                                                 <i class="bi bi-chevron-left"></i>
                                             </a>
                                         </li>
@@ -194,12 +180,12 @@
 
                                     {% if page_obj.has_next %}
                                         <li class="page-item">
-                                            <a class="page-link" href="?page={{ page_obj.next_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if committee_type_filter %}&committee_type={{ committee_type_filter }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if council_filter %}&council={{ council_filter }}{% endif %}">
+                                            <a class="page-link" href="?page={{ page_obj.next_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if committee_type_filter %}&committee_type={{ committee_type_filter }}{% endif %}{% if council_filter %}&council={{ council_filter }}{% endif %}">
                                                 <i class="bi bi-chevron-right"></i>
                                             </a>
                                         </li>
                                         <li class="page-item">
-                                            <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}{% if search_query %}&search={{ search_query }}{% endif %}{% if committee_type_filter %}&committee_type={{ committee_type_filter }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if council_filter %}&council={{ council_filter }}{% endif %}">
+                                            <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}{% if search_query %}&search={{ search_query }}{% endif %}{% if committee_type_filter %}&committee_type={{ committee_type_filter }}{% endif %}{% if council_filter %}&council={{ council_filter }}{% endif %}">
                                                 <i class="bi bi-chevron-double-right"></i>
                                             </a>
                                         </li>
@@ -212,7 +198,7 @@
                             <i class="bi bi-people fs-1 text-muted"></i>
                             <h4 class="mt-3">{% trans "No Committees Found" %}</h4>
                             <p class="text-muted">
-                                {% if search_query or committee_type_filter or status_filter or council_filter %}
+                                {% if search_query or committee_type_filter or council_filter %}
                                     {% trans "No committees match your current filters." %}
                                 {% else %}
                                     {% trans "No committees have been created yet." %}

--- a/app/templates/local/committee_meeting_detail.html
+++ b/app/templates/local/committee_meeting_detail.html
@@ -56,10 +56,11 @@
                                 {% endif %}
                                 <dt class="col-sm-4">{% trans "Status" %}</dt>
                                 <dd class="col-sm-8">
-                                    {% if meeting.is_past %}
-                                        <span class="badge bg-secondary">{% trans "Past" %}</span>
-                                    {% else %}
-                                        <span class="badge bg-success">{% trans "Upcoming" %}</span>
+                                    <span class="badge {% if meeting.status == 'cancelled' %}bg-danger{% elif meeting.status == 'completed' %}bg-secondary{% elif meeting.status == 'invited' %}bg-info{% else %}bg-success{% endif %}">{{ meeting.get_status_display }}</span>
+                                    {% if meeting.is_past and meeting.status == 'scheduled' %}
+                                        <br><small class="text-muted">{% trans "Past" %}</small>
+                                    {% elif not meeting.is_past and meeting.status == 'scheduled' %}
+                                        <br><small class="text-success">{% trans "Upcoming" %}</small>
                                     {% endif %}
                                 </dd>
                             </dl>

--- a/app/templates/local/committee_meeting_form.html
+++ b/app/templates/local/committee_meeting_form.html
@@ -138,6 +138,16 @@
                             {% endif %}
                         </div>
 
+                        {% if 'status' in form.fields %}
+                        <div class="mb-3">
+                            <label for="{{ form.status.id_for_label }}" class="form-label">{% trans "Status" %}</label>
+                            {{ form.status }}
+                            {% if form.status.errors %}
+                                <div class="invalid-feedback d-block">{% for error in form.status.errors %}{{ error }}{% endfor %}</div>
+                            {% endif %}
+                        </div>
+                        {% endif %}
+
                         {% if 'is_active' in form.fields %}
                         <div class="mb-3 form-check">
                             {{ form.is_active }}


### PR DESCRIPTION
- Removed the 'status' field from the Committee model and forms, streamlining committee management.
- Introduced a 'status' field in the CommitteeMeeting model to track meeting statuses with options for 'scheduled', 'completed', 'cancelled', and 'invited'.
- Updated forms and templates to reflect the new status handling for committee meetings, including visibility and display logic.
- Adjusted views to ensure proper permission checks and context handling for committee and meeting statuses.