### PR TITLE
Add support for multiple answer file attachments in motion and inquiry status updates

### DIFF
--- a/app/motion/admin.py
+++ b/app/motion/admin.py
@@ -1,5 +1,9 @@
 from django.contrib import admin
-from .models import Tag, Motion, MotionVote, MotionComment, MotionAttachment, MotionStatus, Inquiry, InquiryStatus, InquiryAttachment
+from .models import (
+    Tag, Motion, MotionVote, MotionComment, MotionAttachment, MotionStatus,
+    MotionStatusAnswerFile, Inquiry, InquiryStatus, InquiryStatusAnswerFile,
+    InquiryAttachment,
+)
 
 
 @admin.register(Tag)
@@ -225,6 +229,26 @@ class InquiryAdmin(admin.ModelAdmin):
         """Display count of supporting parties"""
         return obj.supporting_parties_count
     supporting_parties_count.short_description = 'Supporting Parties'
+
+
+@admin.register(MotionStatusAnswerFile)
+class MotionStatusAnswerFileAdmin(admin.ModelAdmin):
+    """Admin configuration for MotionStatusAnswerFile model"""
+    list_display = ['filename', 'status_entry', 'uploaded_at']
+    list_filter = ['uploaded_at']
+    search_fields = ['filename', 'status_entry__motion__title']
+    readonly_fields = ['uploaded_at']
+    date_hierarchy = 'uploaded_at'
+
+
+@admin.register(InquiryStatusAnswerFile)
+class InquiryStatusAnswerFileAdmin(admin.ModelAdmin):
+    """Admin configuration for InquiryStatusAnswerFile model"""
+    list_display = ['filename', 'status_entry', 'uploaded_at']
+    list_filter = ['uploaded_at']
+    search_fields = ['filename', 'status_entry__inquiry__title']
+    readonly_fields = ['uploaded_at']
+    date_hierarchy = 'uploaded_at'
 
 
 @admin.register(InquiryAttachment)

--- a/app/motion/forms.py
+++ b/app/motion/forms.py
@@ -1,3 +1,5 @@
+import os
+
 from django import forms
 from django.contrib.auth import get_user_model
 from django.forms import BaseFormSet, formset_factory
@@ -1003,6 +1005,29 @@ class InquiryAttachmentForm(forms.ModelForm):
         return instance
 
 
+def validate_answer_pdf_files(files, *, require_at_least_one=False):
+    """Validate uploaded answer PDF files. Returns list of valid files or raises ValidationError."""
+    errors = []
+    valid_files = [f for f in files if f]
+
+    if require_at_least_one and not valid_files:
+        errors.append(_('Please upload at least one written answer PDF when marking as answered.'))
+
+    for uploaded_file in valid_files:
+        ext = os.path.splitext(getattr(uploaded_file, 'name', '') or '')[1].lower()
+        if ext != '.pdf':
+            errors.append(_('Only PDF files are allowed for the written answer.'))
+            break
+        if uploaded_file.size > 20 * 1024 * 1024:
+            errors.append(_('Each file must be smaller than 20 MB.'))
+            break
+
+    if errors:
+        raise forms.ValidationError(errors[0])
+
+    return valid_files
+
+
 class MotionStatusForm(forms.ModelForm):
     """Form for changing motion status with integrated voting"""
     
@@ -1021,19 +1046,14 @@ class MotionStatusForm(forms.ModelForm):
         widget=forms.Select(attrs={'class': 'form-select'}),
         help_text="Select the session where this motion will be tabled"
     )
-    
-    answer_pdf = forms.FileField(
+    answer_files = forms.FileField(
         required=False,
-        widget=forms.FileInput(attrs={
-            'class': 'form-control',
-            'accept': 'application/pdf,.pdf',
-        }),
-        help_text=_("Upload the written answer PDF (required when marking as answered)")
+        widget=forms.HiddenInput(),
     )
-
+    
     class Meta:
         model = MotionStatus
-        fields = ['status', 'committee', 'session', 'reason', 'answer_pdf']
+        fields = ['status', 'committee', 'session', 'reason']
         widgets = {
             'status': forms.Select(attrs={'class': 'form-select'}),
             'committee': forms.Select(attrs={'class': 'form-select'}),
@@ -1141,25 +1161,15 @@ class MotionStatusForm(forms.ModelForm):
                         'committee': f'This motion was referred to {referral_committee.name}. Please select the same committee.'
                     })
         
-        # If status is 'answered', written answer PDF is required
         if status == 'answered':
-            answer_pdf = cleaned_data.get('answer_pdf')
-            if not answer_pdf:
-                raise forms.ValidationError({
-                    'answer_pdf': _('Please upload the written answer PDF when marking the motion as answered.')
-                })
-            # Validate PDF only
-            import os
-            ext = os.path.splitext(getattr(answer_pdf, 'name', '') or '')[1].lower()
-            if ext != '.pdf':
-                raise forms.ValidationError({
-                    'answer_pdf': _('Only PDF files are allowed for the written answer.')
-                })
-            # Max size 20MB
-            if answer_pdf.size > 20 * 1024 * 1024:
-                raise forms.ValidationError({
-                    'answer_pdf': _('The file must be smaller than 20 MB.')
-                })
+            answer_files = self.files.getlist('answer_files') if self.files else []
+            try:
+                cleaned_data['answer_files'] = validate_answer_pdf_files(
+                    answer_files,
+                    require_at_least_one=True,
+                )
+            except forms.ValidationError as exc:
+                self.add_error('answer_files', exc)
         
         return cleaned_data
     
@@ -1184,6 +1194,10 @@ class InquiryStatusForm(forms.ModelForm):
         empty_label="Select a committee...",
         widget=forms.Select(attrs={'class': 'form-select'}),
         help_text="Select the committee to refer this inquiry to"
+    )
+    answer_files = forms.FileField(
+        required=False,
+        widget=forms.HiddenInput(),
     )
     
     class Meta:
@@ -1221,6 +1235,16 @@ class InquiryStatusForm(forms.ModelForm):
             raise forms.ValidationError({
                 'committee': 'A committee must be selected when referring an inquiry to committee.'
             })
+
+        if status == 'answered':
+            answer_files = self.files.getlist('answer_files') if self.files else []
+            try:
+                cleaned_data['answer_files'] = validate_answer_pdf_files(
+                    answer_files,
+                    require_at_least_one=False,
+                )
+            except forms.ValidationError as exc:
+                self.add_error('answer_files', exc)
         
         return cleaned_data
     

--- a/app/motion/migrations/0036_status_answer_files.py
+++ b/app/motion/migrations/0036_status_answer_files.py
@@ -1,0 +1,83 @@
+import os
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def migrate_answer_pdf_to_answer_files(apps, schema_editor):
+    MotionStatus = apps.get_model('motion', 'MotionStatus')
+    MotionStatusAnswerFile = apps.get_model('motion', 'MotionStatusAnswerFile')
+
+    for status_entry in MotionStatus.objects.exclude(answer_pdf='').exclude(answer_pdf__isnull=True):
+        if not status_entry.answer_pdf:
+            continue
+        filename = os.path.basename(status_entry.answer_pdf.name)
+        MotionStatusAnswerFile.objects.create(
+            status_entry_id=status_entry.pk,
+            file=status_entry.answer_pdf,
+            filename=filename or 'answer.pdf',
+        )
+
+
+def reverse_migrate_answer_files(apps, schema_editor):
+    MotionStatus = apps.get_model('motion', 'MotionStatus')
+    MotionStatusAnswerFile = apps.get_model('motion', 'MotionStatusAnswerFile')
+
+    for answer_file in MotionStatusAnswerFile.objects.select_related('status_entry').order_by('uploaded_at'):
+        status_entry = answer_file.status_entry
+        if not status_entry.answer_pdf:
+            status_entry.answer_pdf = answer_file.file
+            status_entry.save(update_fields=['answer_pdf'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('motion', '0035_alter_inquiry_options_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MotionStatusAnswerFile',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('file', models.FileField(upload_to='motion_answers/%Y/%m/%d/')),
+                ('filename', models.CharField(max_length=255)),
+                ('uploaded_at', models.DateTimeField(auto_now_add=True)),
+                ('status_entry', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='answer_files',
+                    to='motion.motionstatus',
+                )),
+            ],
+            options={
+                'verbose_name': 'Motion Status Answer File',
+                'verbose_name_plural': 'Motion Status Answer Files',
+                'ordering': ['uploaded_at'],
+            },
+        ),
+        migrations.CreateModel(
+            name='InquiryStatusAnswerFile',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('file', models.FileField(upload_to='inquiry_answers/%Y/%m/%d/')),
+                ('filename', models.CharField(max_length=255)),
+                ('uploaded_at', models.DateTimeField(auto_now_add=True)),
+                ('status_entry', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='answer_files',
+                    to='motion.inquirystatus',
+                )),
+            ],
+            options={
+                'verbose_name': 'Inquiry Status Answer File',
+                'verbose_name_plural': 'Inquiry Status Answer Files',
+                'ordering': ['uploaded_at'],
+            },
+        ),
+        migrations.RunPython(migrate_answer_pdf_to_answer_files, reverse_migrate_answer_files),
+        migrations.RemoveField(
+            model_name='motionstatus',
+            name='answer_pdf',
+        ),
+    ]

--- a/app/motion/models.py
+++ b/app/motion/models.py
@@ -459,12 +459,6 @@ class MotionStatus(models.Model):
     changed_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name='motion_status_changes')
     changed_at = models.DateTimeField(auto_now_add=True)
     reason = models.TextField(blank=True, help_text="Reason for the status change")
-    answer_pdf = models.FileField(
-        upload_to='motion_answers/%Y/%m/%d/',
-        null=True,
-        blank=True,
-        help_text=_("Written answer PDF (when status is 'answered')")
-    )
     
     class Meta:
         ordering = ['-changed_at']
@@ -473,6 +467,27 @@ class MotionStatus(models.Model):
     
     def __str__(self):
         return f"{self.motion.title} - {self.get_status_display()} ({self.changed_at.strftime('%d.%m.%Y %H:%M')})"
+
+
+class MotionStatusAnswerFile(models.Model):
+    """PDF answer file attached to a motion status entry (when status is 'answered')."""
+
+    status_entry = models.ForeignKey(
+        MotionStatus,
+        on_delete=models.CASCADE,
+        related_name='answer_files',
+    )
+    file = models.FileField(upload_to='motion_answers/%Y/%m/%d/')
+    filename = models.CharField(max_length=255)
+    uploaded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['uploaded_at']
+        verbose_name = "Motion Status Answer File"
+        verbose_name_plural = "Motion Status Answer Files"
+
+    def __str__(self):
+        return f"{self.filename} - {self.status_entry}"
 
 
 class MotionGroupDecision(models.Model):
@@ -639,6 +654,27 @@ class InquiryStatus(models.Model):
         return f"{self.inquiry.title} - {self.get_status_display()} ({self.changed_at.strftime('%d.%m.%Y %H:%M')})"
 
 
+class InquiryStatusAnswerFile(models.Model):
+    """PDF answer file attached to an inquiry status entry (when status is 'answered')."""
+
+    status_entry = models.ForeignKey(
+        InquiryStatus,
+        on_delete=models.CASCADE,
+        related_name='answer_files',
+    )
+    file = models.FileField(upload_to='inquiry_answers/%Y/%m/%d/')
+    filename = models.CharField(max_length=255)
+    uploaded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['uploaded_at']
+        verbose_name = "Inquiry Status Answer File"
+        verbose_name_plural = "Inquiry Status Answer Files"
+
+    def __str__(self):
+        return f"{self.filename} - {self.status_entry}"
+
+
 class InquiryAttachment(models.Model):
     """Model representing file attachments for inquiries"""
     
@@ -674,7 +710,9 @@ auditlog.register(MotionVote)
 auditlog.register(MotionComment)
 auditlog.register(MotionAttachment)
 auditlog.register(MotionStatus)
+auditlog.register(MotionStatusAnswerFile)
 auditlog.register(MotionGroupDecision)
 auditlog.register(Inquiry)
 auditlog.register(InquiryStatus)
+auditlog.register(InquiryStatusAnswerFile)
 auditlog.register(InquiryAttachment)

--- a/app/motion/tests.py
+++ b/app/motion/tests.py
@@ -1,17 +1,24 @@
 from django.test import TestCase, Client
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
+from django import forms
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms import formset_factory
 from django.utils import timezone
+from django.utils.datastructures import MultiValueDict
 from django.urls import reverse
 from datetime import datetime, timedelta
 
 from .forms import (
-    MotionForm, MotionVoteForm, MotionVoteFormSetFactory, 
-    MotionStatusForm, MotionCommentForm, MotionAttachmentForm, 
-    MotionGroupDecisionForm, InquiryForm
+    MotionForm, MotionVoteForm, MotionVoteFormSetFactory,
+    MotionStatusForm, MotionCommentForm, MotionAttachmentForm,
+    MotionGroupDecisionForm, InquiryForm, InquiryStatusForm,
+    validate_answer_pdf_files,
 )
-from .models import Motion, MotionVote, MotionComment, MotionAttachment, MotionStatus, MotionGroupDecision, Inquiry
+from .models import (
+    Motion, MotionVote, MotionComment, MotionAttachment, MotionStatus,
+    MotionStatusAnswerFile, MotionGroupDecision, Inquiry, InquiryStatus,
+    InquiryStatusAnswerFile,
+)
 from local.models import Local, Council, Session, Term, Party, Committee
 from group.models import Group
 
@@ -1080,3 +1087,158 @@ class MotionInquiryStatusPermissionTests(TestCase):
         self.client.login(username='status_admin', password='adminpass123')
         response = self.client.get(self.inquiry_status_change_url)
         self.assertEqual(response.status_code, 200)
+
+
+class StatusAnswerFileTests(TestCase):
+    """Tests for multiple PDF answer attachments on motions and inquiries."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_superuser(
+            username='answer_admin',
+            email='answer_admin@example.com',
+            password='adminpass123',
+        )
+
+        self.local = Local.objects.create(
+            name='Answer Local',
+            code='AL',
+            description='Test local',
+            is_active=True,
+        )
+        self.council = self.local.council
+        self.party = Party.objects.create(
+            name='Answer Party',
+            local=self.local,
+            is_active=True,
+        )
+        self.group = Group.objects.create(
+            name='Answer Group',
+            party=self.party,
+            is_active=True,
+        )
+        self.term = Term.objects.create(
+            name='Answer Term',
+            start_date=timezone.now().date(),
+            end_date=(timezone.now().date() + timedelta(days=365)),
+            is_active=True,
+        )
+        self.session = Session.objects.create(
+            title='Answer Session',
+            council=self.council,
+            term=self.term,
+            scheduled_date=timezone.now() + timedelta(days=1),
+            is_active=True,
+        )
+        self.motion = Motion.objects.create(
+            title='Answer Motion',
+            text='Motion text',
+            session=self.session,
+            group=self.group,
+            submitted_by=self.user,
+            status='approved',
+        )
+        self.inquiry = Inquiry.objects.create(
+            title='Answer Inquiry',
+            text='Inquiry text',
+            session=self.session,
+            group=self.group,
+            submitted_by=self.user,
+            status='approved',
+        )
+
+    def _pdf_file(self, name):
+        return SimpleUploadedFile(name, b'%PDF-1.4 test content', content_type='application/pdf')
+
+    def _pdf_files_dict(self, names):
+        files = MultiValueDict()
+        files.setlist('answer_files', [self._pdf_file(name) for name in names])
+        return files
+
+    def test_validate_answer_pdf_files_requires_at_least_one_for_motions(self):
+        with self.assertRaises(forms.ValidationError):
+            validate_answer_pdf_files([], require_at_least_one=True)
+
+    def test_validate_answer_pdf_files_rejects_non_pdf(self):
+        bad_file = SimpleUploadedFile('answer.txt', b'not a pdf', content_type='text/plain')
+        with self.assertRaises(forms.ValidationError):
+            validate_answer_pdf_files([bad_file], require_at_least_one=True)
+
+    def test_motion_status_form_accepts_multiple_pdfs(self):
+        form = MotionStatusForm(
+            data={'status': 'answered', 'reason': 'Answered'},
+            files=self._pdf_files_dict(['answer1.pdf', 'answer2.pdf']),
+            motion=self.motion,
+            changed_by=self.user,
+            locked_status='answered',
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(len(form.cleaned_data['answer_files']), 2)
+
+    def test_motion_status_form_requires_pdf_when_answered(self):
+        form = MotionStatusForm(
+            data={'status': 'answered', 'reason': 'Answered'},
+            files=MultiValueDict(),
+            motion=self.motion,
+            changed_by=self.user,
+            locked_status='answered',
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn('answer_files', form.errors)
+
+    def test_inquiry_status_form_accepts_zero_or_multiple_pdfs(self):
+        for names in ([], ['answer1.pdf'], ['answer1.pdf', 'answer2.pdf']):
+            with self.subTest(names=names):
+                files = self._pdf_files_dict(names) if names else MultiValueDict()
+                form = InquiryStatusForm(
+                    data={'status': 'answered', 'reason': 'Answered'},
+                    files=files,
+                    inquiry=self.inquiry,
+                    changed_by=self.user,
+                )
+                self.assertTrue(form.is_valid())
+                self.assertEqual(len(form.cleaned_data.get('answer_files', [])), len(names))
+
+    def test_motion_status_change_view_saves_multiple_answer_files(self):
+        self.client.login(username='answer_admin', password='adminpass123')
+        url = reverse('motion:motion-status-change', kwargs={'pk': self.motion.pk}) + '?status=answered'
+        response = self.client.post(
+            url,
+            {
+                'status': 'answered',
+                'reason': 'Written answers',
+                'answer_files': [
+                    self._pdf_file('motion_answer1.pdf'),
+                    self._pdf_file('motion_answer2.pdf'),
+                ],
+            },
+            format='multipart',
+        )
+        self.assertEqual(response.status_code, 302)
+        self.motion.refresh_from_db()
+        self.assertEqual(self.motion.status, 'answered')
+        status_entry = self.motion.status_history.filter(status='answered').first()
+        self.assertIsNotNone(status_entry)
+        self.assertEqual(status_entry.answer_files.count(), 2)
+
+    def test_inquiry_status_change_view_saves_answer_files(self):
+        self.client.login(username='answer_admin', password='adminpass123')
+        url = reverse('inquiry:inquiry-status-change', kwargs={'pk': self.inquiry.pk})
+        response = self.client.post(
+            url,
+            {
+                'status': 'answered',
+                'reason': 'Written answers',
+                'answer_files': [
+                    self._pdf_file('inquiry_answer1.pdf'),
+                    self._pdf_file('inquiry_answer2.pdf'),
+                ],
+            },
+            format='multipart',
+        )
+        self.assertEqual(response.status_code, 302)
+        self.inquiry.refresh_from_db()
+        self.assertEqual(self.inquiry.status, 'answered')
+        status_entry = self.inquiry.status_history.filter(status='answered').first()
+        self.assertIsNotNone(status_entry)
+        self.assertEqual(status_entry.answer_files.count(), 2)

--- a/app/motion/views.py
+++ b/app/motion/views.py
@@ -13,7 +13,11 @@ from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
 from django.core.exceptions import PermissionDenied
 
-from .models import Motion, MotionVote, MotionComment, MotionAttachment, MotionStatus, MotionGroupDecision, Inquiry, InquiryStatus, InquiryAttachment
+from .models import (
+    Motion, MotionVote, MotionComment, MotionAttachment, MotionStatus,
+    MotionStatusAnswerFile, MotionGroupDecision, Inquiry, InquiryStatus,
+    InquiryStatusAnswerFile, InquiryAttachment,
+)
 from .forms import MotionForm, MotionFilterForm, MotionVoteForm, MotionVoteFormSetFactory, MotionVoteTypeForm, MotionCommentForm, MotionAttachmentForm, MotionStatusForm, MotionGroupDecisionForm, InquiryForm, InquiryFilterForm, InquiryStatusForm, InquiryAttachmentForm
 from user.models import CustomUser
 from local.models import Session, Party
@@ -101,6 +105,34 @@ def user_can_delete_inquiry_attachment(user, attachment):
     if user.is_superuser or attachment.uploaded_by_id == user.pk:
         return True
     return is_leader_or_deputy_leader_of_group(user, attachment.inquiry.group)
+
+
+def _save_motion_status_answer_files(status_entry, files):
+    """Persist uploaded PDF answer files for a motion status entry."""
+    import os
+    for uploaded_file in files:
+        if not uploaded_file:
+            continue
+        filename = os.path.basename(getattr(uploaded_file, 'name', '') or '') or 'answer.pdf'
+        MotionStatusAnswerFile.objects.create(
+            status_entry=status_entry,
+            file=uploaded_file,
+            filename=filename,
+        )
+
+
+def _save_inquiry_status_answer_files(status_entry, files):
+    """Persist uploaded PDF answer files for an inquiry status entry."""
+    import os
+    for uploaded_file in files:
+        if not uploaded_file:
+            continue
+        filename = os.path.basename(getattr(uploaded_file, 'name', '') or '') or 'answer.pdf'
+        InquiryStatusAnswerFile.objects.create(
+            status_entry=status_entry,
+            file=uploaded_file,
+            filename=filename,
+        )
 
 
 def can_change_motion_status(user, motion):
@@ -432,7 +464,9 @@ class MotionDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
         ]
 
         # Get status history with votes for vote-results popup
-        context['status_history'] = motion.status_history.prefetch_related('votes', 'votes__party').all()
+        context['status_history'] = motion.status_history.prefetch_related(
+            'votes', 'votes__party', 'answer_files',
+        ).all()
         
         return context
 
@@ -881,7 +915,7 @@ def motion_status_change_view(request, pk):
     requires_votes = initial_status in ['approved', 'rejected', 'refer_to_committee', 'voted_in_committee']
     
     if request.method == 'POST':
-        # Use the status from query parameter, not from POST data (include FILES for answer_pdf upload)
+        # Use the status from query parameter, not from POST data (include FILES for answer file uploads)
         form = MotionStatusForm(request.POST, request.FILES, motion=motion, changed_by=request.user, locked_status=initial_status)
         
         # Only create and validate vote formset if votes are required
@@ -990,14 +1024,16 @@ def motion_status_change_view(request, pk):
             
             logger.debug(f"Motion saved. Old status: {old_status}, New status: {motion.status}")
             
-            # If status is 'answered', attach the uploaded PDF to the new status entry
             if new_status == 'answered':
                 status_entry = motion.status_history.first()
-                answer_pdf = form.cleaned_data.get('answer_pdf')
-                if status_entry and answer_pdf:
-                    status_entry.answer_pdf = answer_pdf
-                    status_entry.save(update_fields=['answer_pdf'])
-                    logger.info(f"Saved answer PDF to status entry {status_entry.pk}")
+                answer_files = form.cleaned_data.get('answer_files', [])
+                if status_entry and answer_files:
+                    _save_motion_status_answer_files(status_entry, answer_files)
+                    logger.info(
+                        "Saved %s answer file(s) to status entry %s",
+                        len(answer_files),
+                        status_entry.pk,
+                    )
             
             # Process vote formset if status requires voting (including refer_no_majority so votes are recorded)
             if new_status in ['approved', 'rejected', 'refer_to_committee', 'refer_no_majority', 'voted_in_committee']:
@@ -1674,7 +1710,9 @@ class InquiryExportPDFView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
         context = super().get_context_data(**kwargs)
         inquiry = self.object
         context['attachments'] = inquiry.attachments.all().order_by('uploaded_at')
-        context['status_history'] = inquiry.status_history.all().order_by('-changed_at')
+        context['status_history'] = inquiry.status_history.prefetch_related(
+            'answer_files',
+        ).all().order_by('-changed_at')
 
         from local.models import Term, TermSeatDistribution
 
@@ -1877,7 +1915,7 @@ class InquiryDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
         ]
 
         # Get status history
-        context['status_history'] = inquiry.status_history.all()
+        context['status_history'] = inquiry.status_history.prefetch_related('answer_files').all()
         
         return context
 
@@ -2082,7 +2120,12 @@ def inquiry_status_change_view(request, pk):
         return redirect('inquiry:inquiry-detail', pk=pk)
     
     if request.method == 'POST':
-        form = InquiryStatusForm(request.POST, inquiry=inquiry, changed_by=request.user)
+        form = InquiryStatusForm(
+            request.POST,
+            request.FILES,
+            inquiry=inquiry,
+            changed_by=request.user,
+        )
         
         if form.is_valid():
             # Get the new status
@@ -2100,6 +2143,12 @@ def inquiry_status_change_view(request, pk):
             
             # Save the inquiry (this will trigger the save method which creates the status history entry)
             inquiry.save()
+
+            if new_status == 'answered':
+                status_entry = inquiry.status_history.first()
+                answer_files = form.cleaned_data.get('answer_files', [])
+                if status_entry and answer_files:
+                    _save_inquiry_status_answer_files(status_entry, answer_files)
             
             messages.success(request, f"Inquiry status changed to '{inquiry.get_status_display()}'.")
             return redirect('inquiry:inquiry-detail', pk=pk)

--- a/app/templates/motion/inquiry_detail.html
+++ b/app/templates/motion/inquiry_detail.html
@@ -121,6 +121,24 @@
                         <h6 class="fw-bold">{% trans "Answer" %}</h6>
                         <p>{{ inquiry.answer|linebreaks }}</p>
                     {% endif %}
+
+                    {% if inquiry.status == 'answered' %}
+                        {% with answered_entry=inquiry.status_history.first %}
+                            {% if answered_entry.answer_files.all %}
+                                <hr>
+                                <h6 class="fw-bold">{% trans "Written answers" %}</h6>
+                                <ul class="list-unstyled mb-0">
+                                    {% for answer_file in answered_entry.answer_files.all %}
+                                        <li class="mb-1">
+                                            <a href="{{ answer_file.file.url }}" target="_blank" rel="noopener" class="text-truncate d-inline-block" style="max-width: 100%;">
+                                                <i class="bi bi-file-pdf"></i> {{ answer_file.filename }}
+                                            </a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+                        {% endwith %}
+                    {% endif %}
                     
                     {% if inquiry.parties.exists %}
                         <hr>
@@ -287,6 +305,15 @@
                                                     <small class="text-muted">
                                                         <i class="bi bi-people"></i> {% trans "Referred to" %}: {{ status_entry.committee.name }}
                                                     </small>
+                                                </div>
+                                            {% endif %}
+                                            {% if status_entry.status == 'answered' and status_entry.answer_files.all %}
+                                                <div class="mt-1 d-flex flex-column gap-1">
+                                                    {% for answer_file in status_entry.answer_files.all %}
+                                                        <a href="{{ answer_file.file.url }}" target="_blank" rel="noopener" class="text-truncate">
+                                                            <i class="bi bi-file-pdf"></i> {{ answer_file.filename }}
+                                                        </a>
+                                                    {% endfor %}
                                                 </div>
                                             {% endif %}
                                         </div>

--- a/app/templates/motion/inquiry_export_pdf.html
+++ b/app/templates/motion/inquiry_export_pdf.html
@@ -62,6 +62,21 @@
     </div>
     {% endif %}
 
+    {% if inquiry.status == 'answered' %}
+        {% with answered_entry=inquiry.status_history.first %}
+            {% if answered_entry.answer_files.all %}
+    <div class="section">
+        <h2>Schriftliche Antworten</h2>
+        <ul>
+            {% for answer_file in answered_entry.answer_files.all %}
+            <li>{{ answer_file.filename }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+            {% endif %}
+        {% endwith %}
+    {% endif %}
+
     {% if ordered_parties %}
     <div class="section">
         <h2>Unterstützende Parteien</h2>
@@ -86,6 +101,9 @@
             {% if entry.changed_by %}<br><small>von {{ entry.changed_by.get_full_name|default:entry.changed_by.username }}</small>{% endif %}
             {% if entry.reason %}<br><small>{{ entry.reason }}</small>{% endif %}
             {% if entry.committee %}<br><small>Ausschuss: {{ entry.committee.name }}</small>{% endif %}
+            {% if entry.status == 'answered' and entry.answer_files.all %}
+            <br><small>{% for answer_file in entry.answer_files.all %}{{ answer_file.filename }}{% if not forloop.last %}, {% endif %}{% endfor %}</small>
+            {% endif %}
         </div>
         {% endfor %}
     </div>

--- a/app/templates/motion/inquiry_status_change.html
+++ b/app/templates/motion/inquiry_status_change.html
@@ -70,7 +70,7 @@
                     <h5 class="mb-0">{% trans "Change Status" %}</h5>
                 </div>
                 <div class="card-body">
-                    <form method="post">
+                    <form method="post" enctype="multipart/form-data">
                         {% csrf_token %}
                         
                         <div class="mb-3">
@@ -90,6 +90,24 @@
                             {% if form.committee.help_text %}
                                 <small class="form-text text-muted">{{ form.committee.help_text }}</small>
                             {% endif %}
+                        </div>
+
+                        <div class="mb-3" id="answer-files-field" style="display: none;">
+                            <label for="answer_files" class="form-label">
+                                <strong>{% trans "Written answer (PDF)" %}</strong>
+                            </label>
+                            <input type="file" name="answer_files" id="answer_files" multiple
+                                   accept="application/pdf,.pdf" class="form-control">
+                            {% if form.errors.answer_files %}
+                                <div class="text-danger">
+                                    {% for error in form.errors.answer_files %}
+                                        <small>{{ error }}</small>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                            <div class="form-text">
+                                {% trans "Upload one or more written answers as PDF (max. 20 MB each). Optional if a text answer is already provided." %}
+                            </div>
                         </div>
 
                         <div class="mb-3">
@@ -175,6 +193,15 @@
                                                     </small>
                                                 </div>
                                             {% endif %}
+                                            {% if status_entry.status == 'answered' and status_entry.answer_files.all %}
+                                                <div class="mt-1 d-flex flex-column gap-1">
+                                                    {% for answer_file in status_entry.answer_files.all %}
+                                                        <a href="{{ answer_file.file.url }}" target="_blank" rel="noopener" class="text-truncate">
+                                                            <i class="bi bi-file-pdf"></i> {{ answer_file.filename }}
+                                                        </a>
+                                                    {% endfor %}
+                                                </div>
+                                            {% endif %}
                                         </div>
                                     </div>
                                 </div>
@@ -195,23 +222,28 @@
 </div>
 
 <script>
-    // Show/hide committee field based on status selection
     document.addEventListener('DOMContentLoaded', function() {
         const statusField = document.getElementById('{{ form.status.id_for_label }}');
         const committeeField = document.getElementById('committee-field');
+        const answerFilesField = document.getElementById('answer-files-field');
+        const committeeInput = document.getElementById('{{ form.committee.id_for_label }}');
         
-        function toggleCommitteeField() {
+        function toggleFields() {
             if (statusField.value === 'refer_to_committee') {
                 committeeField.style.display = 'block';
-                document.getElementById('{{ form.committee.id_for_label }}').required = true;
+                if (committeeInput) committeeInput.required = true;
             } else {
                 committeeField.style.display = 'none';
-                document.getElementById('{{ form.committee.id_for_label }}').required = false;
+                if (committeeInput) committeeInput.required = false;
+            }
+
+            if (answerFilesField) {
+                answerFilesField.style.display = statusField.value === 'answered' ? 'block' : 'none';
             }
         }
         
-        statusField.addEventListener('change', toggleCommitteeField);
-        toggleCommitteeField(); // Initial check
+        statusField.addEventListener('change', toggleFields);
+        toggleFields();
     });
 </script>
 {% endblock content %}

--- a/app/templates/motion/motion_detail.html
+++ b/app/templates/motion/motion_detail.html
@@ -106,11 +106,11 @@
                                     {% elif motion.status == 'answered' %}
                                         <span class="badge bg-success">{% trans "Answered" %}</span>
                                         {% with answered_entry=motion.status_history.first %}
-                                            {% if answered_entry.answer_pdf %}
-                                                <a href="{{ answered_entry.answer_pdf.url }}" target="_blank" rel="noopener" class="ms-2">
-                                                    <i class="bi bi-file-pdf"></i> {% trans "Written answer (PDF)" %}
+                                            {% for answer_file in answered_entry.answer_files.all %}
+                                                <a href="{{ answer_file.file.url }}" target="_blank" rel="noopener" class="ms-2" title="{{ answer_file.filename }}">
+                                                    <i class="bi bi-file-pdf"></i> {{ answer_file.filename|truncatechars:30 }}
                                                 </a>
-                                            {% endif %}
+                                            {% endfor %}
                                         {% endwith %}
                                     {% elif motion.status == 'deleted' %}
                                         <span class="badge bg-secondary">{% trans "Deleted" %}</span>
@@ -526,11 +526,13 @@
                                                     </small>
                                                 </div>
                                             {% endif %}
-                                            {% if status_entry.status == 'answered' and status_entry.answer_pdf %}
-                                                <div class="mt-1">
-                                                    <a href="{{ status_entry.answer_pdf.url }}" target="_blank" rel="noopener">
-                                                        <i class="bi bi-file-pdf"></i> {% trans "Written answer (PDF)" %}
-                                                    </a>
+                                            {% if status_entry.status == 'answered' and status_entry.answer_files.all %}
+                                                <div class="mt-1 d-flex flex-column gap-1">
+                                                    {% for answer_file in status_entry.answer_files.all %}
+                                                        <a href="{{ answer_file.file.url }}" target="_blank" rel="noopener" class="text-truncate">
+                                                            <i class="bi bi-file-pdf"></i> {{ answer_file.filename }}
+                                                        </a>
+                                                    {% endfor %}
                                                 </div>
                                             {% endif %}
                                         </div>

--- a/app/templates/motion/motion_status_change.html
+++ b/app/templates/motion/motion_status_change.html
@@ -155,19 +155,20 @@
                         </div>
                         
                         <div class="mb-3" id="answer-pdf-field" style="display: none;">
-                            <label for="{{ form.answer_pdf.id_for_label }}" class="form-label">
+                            <label for="answer_files" class="form-label">
                                 <strong>{% trans "Written answer (PDF)" %}</strong>
                             </label>
-                            {{ form.answer_pdf }}
-                            {% if form.answer_pdf.errors %}
+                            <input type="file" name="answer_files" id="answer_files" multiple
+                                   accept="application/pdf,.pdf" class="form-control">
+                            {% if form.errors.answer_files %}
                                 <div class="text-danger">
-                                    {% for error in form.answer_pdf.errors %}
+                                    {% for error in form.errors.answer_files %}
                                         <small>{{ error }}</small>
                                     {% endfor %}
                                 </div>
                             {% endif %}
                             <div class="form-text">
-                                {% trans "Upload the written answer as PDF (max. 20 MB). Required when marking as answered." %}
+                                {% trans "Upload one or more written answers as PDF (max. 20 MB each). At least one file is required when marking as answered." %}
                             </div>
                         </div>
                         


### PR DESCRIPTION
- Introduced `MotionStatusAnswerFile` and `InquiryStatusAnswerFile` models to handle multiple PDF attachments for motion and inquiry statuses marked as 'answered'.
- Updated forms to validate and process multiple file uploads, ensuring at least one file is required when marking as answered.
- Enhanced views to save uploaded files and display them in the status history.
- Modified templates to show links to uploaded answer files in both motion and inquiry detail views.
- Added tests to verify the functionality of multiple file uploads and their handling in status changes.