### PR TITLE
Fix MotionCreateView and InquiryCreateView permissions for group members

### DIFF
--- a/app/motion/tests.py
+++ b/app/motion/tests.py
@@ -920,6 +920,26 @@ class MotionCreateViewTests(TestCase):
         motion = Motion.objects.get(title='Test Motion')
         self.assertEqual(motion.session, self.session)
 
+    def test_group_member_can_access_motion_create_without_session_param(self):
+        """Regular group members should be able to create motions even without ?session=..."""
+        from group.models import GroupMember
+        user = User.objects.create_user(username='groupmember', password='testpass123')
+        GroupMember.objects.create(user=user, group=self.group, is_active=True)
+        self.client.login(username='groupmember', password='testpass123')
+
+        response = self.client.get(reverse('motion:motion-create'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_group_member_can_access_motion_create_with_session_param(self):
+        """Regular group members should be able to create motions with ?session=..."""
+        from group.models import GroupMember
+        user = User.objects.create_user(username='groupmember2', password='testpass123')
+        GroupMember.objects.create(user=user, group=self.group, is_active=True)
+        self.client.login(username='groupmember2', password='testpass123')
+
+        response = self.client.get(f"{reverse('motion:motion-create')}?session={self.session.pk}")
+        self.assertEqual(response.status_code, 200)
+
 
 class MotionInquiryStatusPermissionTests(TestCase):
     """Tests for motion and inquiry status-change permissions for group managers."""

--- a/app/motion/tests_inquiry.py
+++ b/app/motion/tests_inquiry.py
@@ -482,6 +482,26 @@ class InquiryCreateViewTests(TestCase):
         inquiry = Inquiry.objects.get(title='Test Inquiry')
         self.assertEqual(inquiry.submitted_by, self.superuser)
 
+    def test_group_member_can_access_inquiry_create_without_session_param(self):
+        """Regular group members should be able to create inquiries even without ?session=..."""
+        from group.models import GroupMember
+        user = User.objects.create_user(username='groupmember', password='testpass123')
+        GroupMember.objects.create(user=user, group=self.group, is_active=True)
+        self.client.login(username='groupmember', password='testpass123')
+
+        response = self.client.get(reverse('inquiry:inquiry-create'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_group_member_can_access_inquiry_create_with_session_param(self):
+        """Regular group members should be able to create inquiries with ?session=..."""
+        from group.models import GroupMember
+        user = User.objects.create_user(username='groupmember2', password='testpass123')
+        GroupMember.objects.create(user=user, group=self.group, is_active=True)
+        self.client.login(username='groupmember2', password='testpass123')
+
+        response = self.client.get(f"{reverse('inquiry:inquiry-create')}?session={self.session.pk}")
+        self.assertEqual(response.status_code, 200)
+
 
 class InquiryUpdateViewTests(TestCase):
     """Test cases for InquiryUpdateView"""

--- a/app/motion/views.py
+++ b/app/motion/views.py
@@ -479,18 +479,13 @@ class MotionCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     success_url = reverse_lazy('motion:motion-list')
 
     def test_func(self):
-        """Allow superuser, motion.create permission, or regular group members for the session's council."""
+        """Allow superuser, motion.create permission, or regular group members."""
         user = self.request.user
         if user.is_superuser or user.has_role_permission('motion.create'):
             return True
-        session_id = self.request.GET.get('session')
-        if session_id:
-            try:
-                council_id = Session.objects.filter(pk=session_id).values_list('council_id', flat=True).first()
-                if council_id is not None and council_id in _get_user_accessible_council_ids(user):
-                    return True
-            except (ValueError, TypeError):
-                pass
+        group_ids = _get_user_accessible_group_ids(user)
+        if group_ids is not None and len(group_ids) > 0:
+            return True
         return False
 
     def get_form_kwargs(self):
@@ -1928,18 +1923,13 @@ class InquiryCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     success_url = reverse_lazy('inquiry:inquiry-list')
 
     def test_func(self):
-        """Allow superuser, motion.create permission, or regular group members for the session's council."""
+        """Allow superuser, motion.create permission, or regular group members."""
         user = self.request.user
         if user.is_superuser or user.has_role_permission('motion.create'):
             return True
-        session_id = self.request.GET.get('session')
-        if session_id:
-            try:
-                council_id = Session.objects.filter(pk=session_id).values_list('council_id', flat=True).first()
-                if council_id is not None and council_id in _get_user_accessible_council_ids(user):
-                    return True
-            except (ValueError, TypeError):
-                pass
+        group_ids = _get_user_accessible_group_ids(user)
+        if group_ids is not None and len(group_ids) > 0:
+            return True
         return False
 
     def get_form_kwargs(self):


### PR DESCRIPTION
**Bug:** Regular group members without the explicit `motion.create` role permission received a 403 when trying to create motions or inquiries from the list page (`/motions/create/`, `/inquiries/create/`).

**Root cause:** The create views only checked group membership when a session was pre-selected via `?session=...` in the URL. The "Create Motion/Inquiry" buttons on the list pages link directly to the create URLs without any session parameter, so the council-membership check never ran and the code fell through to `return False`.

**Fix:** Aligns `MotionCreateView.test_func` and `InquiryCreateView.test_func` with `MotionListView` / `MotionUpdateView` by checking `_get_user_accessible_group_ids(user)` directly. Any active group member can now create motions/inquiries for their group.

**Tests added:** 4 new tests covering group member access with and without session parameters.
